### PR TITLE
Set height to auto when using increase/decrease buttons.

### DIFF
--- a/css/style.css
+++ b/css/style.css
@@ -24,7 +24,7 @@
 
 .ring-sizer-container {
   text-align: center;
-  font-family: "omnes-pro", Open Sans;
+  font-family: "omnes-pro", dosis, Open Sans;
   font-size: 18px;
   line-height: 1.2em;
   font-weight: 300;

--- a/index.html
+++ b/index.html
@@ -5,12 +5,10 @@
     <meta name="viewport" content="width=device-width, initial-scale=1">
     <link rel="stylesheet" href="https://code.jquery.com/ui/1.12.1/themes/base/jquery-ui.css">
     <link rel="stylesheet" href="https://jqueryui.com/resources/demos/style.css">
-    <!-- <link rel="stylesheet" type="text/css" href="https://cdn.rawgit.com/stephchuolee/ringer-sizer/56f8dbd5c95ba2941ad1748fac79ed3d5dbcf28f/css/style.css"> -->
     <link rel="stylesheet" href="css/style.css">
     <link href="https://fonts.googleapis.com/css?family=Dosis" rel="stylesheet">
     <script src="https://code.jquery.com/jquery-1.12.4.js"></script>
     <script src="https://code.jquery.com/ui/1.12.1/jquery-ui.js"></script>
-    <!-- <script src="https://cdn.rawgit.com/stephchuolee/ringer-sizer/56f8dbd5c95ba2941ad1748fac79ed3d5dbcf28f/js/main.js"></script> -->
     <script src="js/main.js"></script>
   </head>
 

--- a/js/main.js
+++ b/js/main.js
@@ -1,13 +1,13 @@
-$(function(){
+$(function() {
   var card = $('#card-container');
   var cardBaseWidth = card.width();
-
+  var aspectRatio = 312 / 196;
   card.resizable({
-    aspectRatio: 312 / 196,
+    aspectRatio: aspectRatio,
     handles: 'se',
   });
 
-  card.on('resizestop', function(){
+  card.on('resizestop', function() {
     updateAllRings(rings, cardBaseWidth, card.width());
   });
 
@@ -29,12 +29,14 @@ $(function(){
     "ring-11": 77.11620928,
   };
 
-  $('#increase-btn').on('click', function(){
+  $('#increase-btn').on('click', function() {
+    card.css('height', 'auto');
     card.css('width', '+=2');
     updateAllRings(rings, cardBaseWidth, card.width());
   });
 
-  $('#decrease-btn').on('click', function(){
+  $('#decrease-btn').on('click', function() {
+    card.css('height', 'auto');
     card.css('width', '-=2');
     updateAllRings(rings, cardBaseWidth, card.width());
   });


### PR DESCRIPTION
The bug: Using the drag and then switching back to the buttons resulted in only the width changing.

The buttons only affect the width of the card-container and rely on the height to auto-size with the aspect ratio. Since a height is never specified the buttons work correctly on their own. When resizable is used it explicitly sets a height for the card-container, which disables the auto-sizing for the height when you switch back to the buttons.